### PR TITLE
docs(engine): add spec files for engine modules

### DIFF
--- a/engine/canvas.spec.md
+++ b/engine/canvas.spec.md
@@ -1,0 +1,12 @@
+engine/canvas.ts
+Purpose: Canvas setup and rendering operations
+
+```typescript
+export class CanvasRenderer {
+  // setupCanvas(element, width, height)
+  // clear() - fill with white
+  // drawSprite(sprite, x, y) - draw black pixels
+  // drawText(text, x, y) - for UI
+  // pixel-perfect rendering setup
+}
+```

--- a/engine/collision.spec.md
+++ b/engine/collision.spec.md
@@ -1,0 +1,11 @@
+engine/collision.ts
+Purpose: Pixel-perfect collision detection
+
+```typescript
+export class CollisionDetector {
+  // checkCollision(obj1, obj2) - pixel-perfect check
+  // checkAllCollisions(objects) - return collision map
+  // optimizations: bounding box pre-check
+  // returns Map<GameObject, GameObject[]> for each object's collisions
+}
+```

--- a/engine/index.spec.md
+++ b/engine/index.spec.md
@@ -1,0 +1,14 @@
+engine/index.ts
+Purpose: Main entry point and engine orchestration
+
+```typescript
+export class OneClickEngine {
+  // Core engine initialization and public API
+  // Combines all subsystems (canvas, input, objects, etc.)
+  // Exposes methods: start(), stop(), addObject(), removeObject()
+}
+
+export { GameObject } from './object';
+export { Sprite, createSpriteFromAscii } from './sprite';
+export * from './types';
+```

--- a/engine/input.spec.md
+++ b/engine/input.spec.md
@@ -1,0 +1,11 @@
+engine/input.ts
+Purpose: Input state management
+
+```typescript
+export class InputManager {
+  // setupEventListeners()
+  // updateButtonState() - handle pressed/released transitions
+  // getCurrentButtonState() - returns ButtonState
+  // supports keyboard (space), mouse, and touch
+}
+```

--- a/engine/object.spec.md
+++ b/engine/object.spec.md
@@ -1,0 +1,13 @@
+engine/object.ts
+Purpose: GameObject base class
+
+```typescript
+export abstract class GameObject {
+  // Properties: x, y, currentState, states, active, layer
+  // addState(name, sprite)
+  // setState(name)
+  // getCurrentSprite()
+  // abstract update(buttonState, collisions)
+  // render(renderer) - default sprite rendering
+}
+```

--- a/engine/sprite.spec.md
+++ b/engine/sprite.spec.md
@@ -1,0 +1,15 @@
+engine/sprite.ts
+Purpose: Sprite creation and pixel data management
+
+```typescript
+export class Sprite {
+  // constructor(width, height, pixels)
+  // isPixelSolid(x, y) - check if pixel is black
+  // getBounds() - get width/height
+}
+
+export function createSpriteFromAscii(ascii: string): Sprite;
+// Parse ASCII art into sprite data
+// # = black pixel, space/other = white pixel
+// Handle multi-line strings
+```

--- a/engine/types.spec.md
+++ b/engine/types.spec.md
@@ -1,0 +1,10 @@
+engine/types.ts
+Purpose: TypeScript type definitions
+
+```typescript
+// ButtonState interface
+// Position interface (x, y)
+// GameState enum ('playing', 'paused', 'gameOver')
+// Engine configuration types
+// Collision result types
+```

--- a/engine/update.spec.md
+++ b/engine/update.spec.md
@@ -1,0 +1,12 @@
+engine/update.ts
+Purpose: Game loop and object updates
+
+```typescript
+export class GameLoop {
+  // gameLoop(timestamp) - main RAF loop
+  // updateObjects(objects, buttonState, collisions)
+  // handleInactiveObjects(objects) - remove inactive
+  // sortObjectsByLayer(objects) - for rendering
+  // timing and frame rate management
+}
+```

--- a/engine/utils.spec.md
+++ b/engine/utils.spec.md
@@ -1,0 +1,10 @@
+engine/utils.ts
+Purpose: Helper functions and utilities
+
+```typescript
+// clamp(value, min, max)
+// roundToPixel(value) - round to integer
+// getBoundingBox(sprite, x, y) - get AABB
+// parseAsciiArt(ascii) - helper for sprite creation
+// debug/logging utilities
+```


### PR DESCRIPTION
Summary
Adds specification markdown files under `engine/` to define the intended structure and responsibilities for upcoming engine modules. These are documentation/specs only; no runtime code changes.

Changes
- engine/index.spec.md — OneClickEngine entry point and exports
- engine/types.spec.md — core types (ButtonState, Position, GameState, config, collision results)
- engine/canvas.spec.md — CanvasRenderer responsibilities and methods
- engine/input.spec.md — InputManager responsibilities and methods
- engine/sprite.spec.md — Sprite class and ASCII sprite factory
- engine/object.spec.md — GameObject base class and lifecycle
- engine/collision.spec.md — CollisionDetector pixel-perfect checks
- engine/update.spec.md — GameLoop timing and update order
- engine/utils.spec.md — utilities (clamp, rounding, AABB, ASCII parsing, logging)

Motivation
These specs establish a clear, modular architecture for the engine and provide a shared reference before implementing the actual TypeScript modules. This should streamline development and code review for subsequent PRs.

Notes
- No changes to existing `src/` code or build/test configuration
- Tests and CI should remain unaffected

Checklist
- [x] Follows repository structure and naming
- [x] No breaking changes
- [x] Ready for discussion/feedback on content and placement

Follow-ups
- Implement the modules per these specs in subsequent PRs
- Align `src/index.ts` exports with the new engine entry once implemented

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/278bbab3dabc49f598dbca5f6d3915b1)