### PR TITLE
feat(engine): add GameObject base class (engine/object.ts)

### DIFF
--- a/engine/object.ts
+++ b/engine/object.ts
@@ -1,0 +1,48 @@
+export type Sprite = number[][];
+
+export interface Renderer {
+  drawSprite(sprite: Sprite, x: number, y: number): void;
+}
+
+export interface ButtonState {
+  [key: string]: boolean;
+}
+
+export type Collision = unknown;
+
+export abstract class GameObject {
+  x: number;
+  y: number;
+  currentState?: string;
+  states: Map<string, Sprite> = new Map();
+  active = true;
+  layer: number;
+
+  constructor(x = 0, y = 0, layer = 0) {
+    this.x = x;
+    this.y = y;
+    this.layer = layer;
+  }
+
+  addState(name: string, sprite: Sprite): void {
+    this.states.set(name, sprite);
+    if (!this.currentState) this.currentState = name;
+  }
+
+  setState(name: string): void {
+    if (!this.states.has(name)) throw new Error(`State not found: ${name}`);
+    this.currentState = name;
+  }
+
+  getCurrentSprite(): Sprite | undefined {
+    return this.currentState ? this.states.get(this.currentState) : undefined;
+  }
+
+  abstract update(buttonState: ButtonState, collisions: Collision[]): void;
+
+  render(renderer: Renderer): void {
+    if (!this.active) return;
+    const sprite = this.getCurrentSprite();
+    if (sprite) renderer.drawSprite(sprite, this.x, this.y);
+  }
+}


### PR DESCRIPTION
Summary
- Implemented GameObject base class in engine/object.ts as specified in engine/object.spec.md

Details
- Added properties: x, y, currentState, states, active, layer
- Added methods: addState(name, sprite), setState(name), getCurrentSprite(), abstract update(buttonState, collisions), render(renderer)
- Included minimal local types (Sprite, Renderer, ButtonState, Collision) for self-contained implementation

Testing
- No tests added or modified in this PR
- Existing CI should pass as change is additive and does not affect current tests

Checklist
- [x] Follows spec in engine/object.spec.md
- [x] No changes outside requested file
- [x] Builds/lints under existing configuration (no project-wide changes)

Notes
- If a centralized types module (engine/types.ts) is introduced later, we can refactor types accordingly.



@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cf1e070363ef49b8b83e29b69581dda3)