### PR TITLE
fix(rendering): clear canvas each frame to prevent trails when object…

### DIFF
--- a/engine/object.ts
+++ b/engine/object.ts
@@ -1,6 +1,7 @@
 import { Sprite } from './sprite.js';
 
 export interface Renderer {
+  clear(): void;
   drawSprite(sprite: Sprite, x: number, y: number): void;
 }
 

--- a/engine/update.ts
+++ b/engine/update.ts
@@ -120,6 +120,8 @@ export class GameLoop {
 
     // Render after updates
     if (this.renderer) {
+      // Clear the frame before rendering to avoid trails
+      this.renderer.clear();
       const sorted = this.sortObjectsByLayer(this.objects);
       for (const obj of sorted) obj.render(this.renderer);
     }


### PR DESCRIPTION
…s move\n\n- Add clear() to Renderer interface\n- Call renderer.clear() before drawing in game loop\n\nCo-authored-by: openhands <openhands@all-hands.dev>